### PR TITLE
ignore node_modules and dist directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules


### PR DESCRIPTION
This PR ignores the `node_modules` and `dist` directories.

fix #7