### PR TITLE
Fixed label position when there is content above the graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "force-graph",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "2D force-directed graph rendered on HTML5 canvas",
   "unpkg": "dist/force-graph.min.js",
   "main": "dist/force-graph.common.js",

--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -352,8 +352,8 @@ export default Kapsule({
       mousePos.y = ev.pageY - offset.top;
 
       // Move tooltip
-      toolTipElem.style.top = `${mousePos.y}px`;
-      toolTipElem.style.left = `${mousePos.x}px`;
+      toolTipElem.style.top = `${ev.pageY}px`;
+      toolTipElem.style.left = `${ev.pageX}px`;
 
       //
 


### PR DESCRIPTION
Previously the code captured the mouse position relative to the canvas and used that to set the tooltip position. This change sets the tooltip to the mouse position (regardless of where the canvas is on the page). This ensures the tooltip is always near the mouse, even when content is above the graph.

### Before the change:
![kapture 2018-09-27 at 9 22 11](https://user-images.githubusercontent.com/3439382/46150032-9c89c880-c239-11e8-953e-59594574223d.gif)

### After the change:
![kapture 2018-09-27 at 9 19 41](https://user-images.githubusercontent.com/3439382/46150030-9c89c880-c239-11e8-8460-4b324fa97d2e.gif)

This pull request will close https://github.com/vasturiano/react-force-graph/issues/42