### PR TITLE
Don't set zoom in onFinishLoading when no nodes in graph

### DIFF
--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -360,7 +360,7 @@ export default Kapsule({
 
     state.forceGraph.onFinishLoading(() => {
       // re-zoom, if still in default position (not user modified)
-      if (d3ZoomTransform(state.canvas).k === state.lastSetZoom) {
+      if (d3ZoomTransform(state.canvas).k === state.lastSetZoom && state.graphData.nodes.length) {
         state.zoom.scaleTo(state.zoom.__baseElem,
           state.lastSetZoom = ZOOM2NODES_FACTOR / Math.cbrt(state.graphData.nodes.length)
         );


### PR DESCRIPTION
In `onFinishLoading` when no nodes are present in the graph, `lastSetZoom` will be `Infinity` and the zoom factor set to the max of 1000 (because of divide by zero).