### PR TITLE
Add new render method: pushParticle

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ myGraph(<myDOMElement>)
 | <b>centerAt</b>([<i>x</i>], [<i>y</i>], [<i>ms</i>]) | Getter/setter for the coordinates of the center of the viewport. This method can be used to perform panning on the canvas programmatically. Each of the `x, y` coordinates is optional, allowing for motion in just one dimension. An optional 3rd argument defines the duration of the transition (in ms) to animate the canvas motion. A value of 0 (default) centers immediately in the final position. | 0,0 |
 | <b>zoom</b>([<i>num</i>], [<i>ms</i>]) | Getter/setter for the canvas zoom amount. The zoom is defined in terms of the scale transform of each px. A value of `1` indicates unity, larger values zoom in and smaller values zoom out. An optional 2nd argument defines the duration of the transition (in ms) to animate the canvas motion. A value of 0 (default) jumps immediately to the final position. | By default the zoom is set to a value inversely proportional to the amount of nodes in the system. |
 | <b>refresh</b>() | Redraws all the nodes/links and reheats the force simulation engine. |
-| <b>pushDirectionalParticle</b>(<i>[source]</i>, <i>[target]</i>, <i>[props]</i>) | Emit a particle in a specific link. Props could be: `{ speed: num, width: num, color: str }` |
+| <b>pushParticle</b>(<i>[source]</i>, <i>[target]</i>, <i>[props]</i>) | Emit a particle in a specific link. Props could be: `{ speed: num, width: num, color: str }`. The particle doesn't respect the link direction. |
 
 ### Force engine (d3-force) configuration
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ myGraph(<myDOMElement>)
 | <b>centerAt</b>([<i>x</i>], [<i>y</i>], [<i>ms</i>]) | Getter/setter for the coordinates of the center of the viewport. This method can be used to perform panning on the canvas programmatically. Each of the `x, y` coordinates is optional, allowing for motion in just one dimension. An optional 3rd argument defines the duration of the transition (in ms) to animate the canvas motion. A value of 0 (default) centers immediately in the final position. | 0,0 |
 | <b>zoom</b>([<i>num</i>], [<i>ms</i>]) | Getter/setter for the canvas zoom amount. The zoom is defined in terms of the scale transform of each px. A value of `1` indicates unity, larger values zoom in and smaller values zoom out. An optional 2nd argument defines the duration of the transition (in ms) to animate the canvas motion. A value of 0 (default) jumps immediately to the final position. | By default the zoom is set to a value inversely proportional to the amount of nodes in the system. |
 | <b>refresh</b>() | Redraws all the nodes/links and reheats the force simulation engine. |
+| <b>pushDirectionalParticle</b>(<i>source: [num or str]</i>, <i>target: [num or str]</i>, <i>props: { speed: num, width: num, color: str }</i>) | Emit a particle in a specific link. |
 
 ### Force engine (d3-force) configuration
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ myGraph(<myDOMElement>)
 | <b>centerAt</b>([<i>x</i>], [<i>y</i>], [<i>ms</i>]) | Getter/setter for the coordinates of the center of the viewport. This method can be used to perform panning on the canvas programmatically. Each of the `x, y` coordinates is optional, allowing for motion in just one dimension. An optional 3rd argument defines the duration of the transition (in ms) to animate the canvas motion. A value of 0 (default) centers immediately in the final position. | 0,0 |
 | <b>zoom</b>([<i>num</i>], [<i>ms</i>]) | Getter/setter for the canvas zoom amount. The zoom is defined in terms of the scale transform of each px. A value of `1` indicates unity, larger values zoom in and smaller values zoom out. An optional 2nd argument defines the duration of the transition (in ms) to animate the canvas motion. A value of 0 (default) jumps immediately to the final position. | By default the zoom is set to a value inversely proportional to the amount of nodes in the system. |
 | <b>refresh</b>() | Redraws all the nodes/links and reheats the force simulation engine. |
-| <b>pushDirectionalParticle</b>(<i>source: [num or str]</i>, <i>target: [num or str]</i>, <i>props: { speed: num, width: num, color: str }</i>) | Emit a particle in a specific link. |
+| <b>pushDirectionalParticle</b>(<i>[source]</i>, <i>[target]</i>, <i>[props]</i>) | Emit a particle in a specific link. Props could be: `{ speed: num, width: num, color: str }` |
 
 ### Force engine (d3-force) configuration
 

--- a/example/push-particle/index.html
+++ b/example/push-particle/index.html
@@ -1,0 +1,41 @@
+<head>
+  <style> body { margin: 0; } </style>
+
+  <!--<script src="//unpkg.com/force-graph"></script>-->
+  <script src="../../dist/force-graph.js"></script>
+</head>
+
+<body>
+  <button id="push-random-particle">Push 10 Random Particle</button>
+  <div id="graph"></div>
+
+  <script>
+    // Random tree
+    const N = 50;
+    const links = [...Array(N).keys()]
+      .filter(id => id)
+      .map(id => ({
+        source: id,
+        target: Math.round(Math.random() * (id-1))
+      }));
+    const gData = {
+      nodes: [...Array(N).keys()].map(i => ({ id: i })),
+      links
+    };
+
+    const Graph = ForceGraph()
+      (document.getElementById('graph'))
+        .graphData(gData);
+
+    const colors = ['red', 'green', 'blue', 'black'];
+    document.getElementById('push-random-particle').addEventListener('click', () => {
+      [...Array(10).keys()].forEach(() => {
+        const link = links[Math.floor(Math.random() * links.length)];
+        Graph.pushParticle(link.source.id, link.target.id, {
+          speed: 0.04,
+          color: colors[Math.floor(Math.random() * colors.length)]
+        });
+      });
+    });
+  </script>
+</body>

--- a/src/canvas-force-graph.js
+++ b/src/canvas-force-graph.js
@@ -70,7 +70,8 @@ export default Kapsule({
     onFinishLoading: { default: () => {}, triggerUpdate: false },
     onEngineTick: { default: () => {}, triggerUpdate: false },
     onEngineStop: { default: () => {}, triggerUpdate: false },
-    isShadow: { default: false, triggerUpdate: false }
+    isShadow: { default: false, triggerUpdate: false },
+    particlesPushed: { default: [], triggerUpdate: false }
   },
 
   methods: {
@@ -86,6 +87,9 @@ export default Kapsule({
       state.forceLayout.force(forceName, forceFn); // Force setter
       return this;
     },
+    pushDirectionalParticle: function(state, source, target, props = {}) {
+      state.particlesPushed.push({ source, target, props })
+    },
     // reset cooldown state
     resetCountdown: function(state) {
       state.cntTicks = 0;
@@ -98,6 +102,7 @@ export default Kapsule({
       paintLinks();
       paintArrows();
       paintPhotons();
+      paintPushedPhotons();
       paintNodes();
 
       return this;
@@ -372,6 +377,73 @@ export default Kapsule({
             ctx.beginPath();
             ctx.arc(coords.x, coords.y, photonR, 0, 2 * Math.PI, false);
             ctx.fill();
+          });
+        });
+        ctx.restore();
+      }
+
+
+      function paintPushedPhotons() {
+        const getSpeed = accessorFn(state.linkDirectionalParticleSpeed);
+        const getDiameter = accessorFn(state.linkDirectionalParticleWidth);
+        const getVisibility = accessorFn(state.linkVisibility);
+        const getColor = accessorFn(state.linkDirectionalParticleColor || state.linkColor);
+        const ctx = state.ctx;
+
+        ctx.save();
+        state.graphData.links.filter(getVisibility).forEach(link => {
+          const { source, target } = link;
+          if (!source.hasOwnProperty('x') || !target.hasOwnProperty('x')) return; // skip invalid link
+
+          link.__pushedPhotons = link.__pushedPhotons || new Set()
+          state.particlesPushed = state.particlesPushed.filter((p) => {
+            if (source.id === p.source && target.id === p.target) {
+              link.__pushedPhotons.add({ inverse: false, props: p.props })
+              return false
+            }
+
+            if (source.id === p.target && target.id === p.source) {
+              link.__pushedPhotons.add({ inverse: true, props: p.props })
+              return false
+            }
+
+            return true
+          })
+
+          const photons = link.__pushedPhotons
+
+          photons.forEach((photon) => {
+            const { props } = photon
+            const particleSpeed = props.speed || getSpeed(link);
+            const photonR = Math.max(0, props.diameter || getDiameter(link) / 2) / Math.sqrt(state.globalScale);
+            const photonColor = props.color || getColor(link) || 'rgba(0,0,0,0.28)';
+            ctx.fillStyle = photonColor;
+
+            const start = photon.inverse ? target : source
+            const end = photon.inverse ? source : target
+
+            // Construct bezier for curved lines
+            const bzLine = link.__controlPoints
+              ? new Bezier(start.x, start.y, ...link.__controlPoints, end.x, end.y)
+              : null;
+
+            const photonPosRatio = photon.__progressRatio =
+              ((photon.__progressRatio || 0) + particleSpeed) % 1;
+
+            const coords = bzLine
+              ? bzLine.get(photonPosRatio)  // get position along bezier line
+              : { // straight line: interpolate linearly
+                x: start.x + (end.x - start.x) * photonPosRatio || 0,
+                y: start.y + (end.y - start.y) * photonPosRatio || 0
+              };
+
+            ctx.beginPath();
+            ctx.arc(coords.x, coords.y, photonR, 0, 2 * Math.PI, false);
+            ctx.fill();
+            const next = ((photon.__progressRatio || (idx / photons.size)) + particleSpeed) % 1
+            if (next < photon.__progressRatio) {
+              photons.delete(photon)
+            }
           });
         });
         ctx.restore();

--- a/src/canvas-force-graph.js
+++ b/src/canvas-force-graph.js
@@ -87,7 +87,7 @@ export default Kapsule({
       state.forceLayout.force(forceName, forceFn); // Force setter
       return this;
     },
-    pushDirectionalParticle: function(state, source, target, props = {}) {
+    pushParticle: function(state, source, target, props = {}) {
       state.particlesPushed.push({ source, target, props })
     },
     // reset cooldown state

--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -58,7 +58,7 @@ const linkedProps = Object.assign(
 const linkedMethods = Object.assign(...[
   'd3Force',
   'refresh',
-  'pushDirectionalParticle'
+  'pushParticle'
 ].map(p => ({ [p]: bindFG.linkMethod(p)})));
 
 function adjustCanvasSize(state) {

--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -57,7 +57,8 @@ const linkedProps = Object.assign(
 );
 const linkedMethods = Object.assign(...[
   'd3Force',
-  'refresh'
+  'refresh',
+  'pushDirectionalParticle'
 ].map(p => ({ [p]: bindFG.linkMethod(p)})));
 
 function adjustCanvasSize(state) {


### PR DESCRIPTION
This is related with: https://github.com/vasturiano/force-graph/issues/54

It adds a new method: `pushParticle(source, target, { speed, color, width })`

I added a new example to show how it works.