### PR TITLE
Expose event object on node and link click events

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ myGraph(<myDOMElement>)
 
 | Method | Description | Default |
 | --- | --- | :--: |
-| <b>onNodeClick</b>(<i>fn</i>) | Callback function for node (left-button) clicks. The node object is included as single argument `onNodeClick(node)`. | - |
+| <b>onNodeClick</b>(<i>fn</i>) | Callback function for node (left-button) clicks. The node object and the event object from the click event are included `onNodeClick(node, event)`. | - |
 | <b>onNodeRightClick</b>(<i>fn</i>) | Callback function for node right-clicks. The node object is included as single argument `onNodeRightClick(node)`. | - |
 | <b>onNodeHover</b>(<i>fn</i>) | Callback function for node mouse over events. The node object (or `null` if there's no node under the mouse line of sight) is included as the first argument, and the previous node object (or null) as second argument: `onNodeHover(node, prevNode)`. | - |
 | <b>onNodeDrag</b>(<i>fn</i>) | Callback function for node drag interactions. This function is invoked repeatedly while dragging a node, every time its position is updated. The node object is included as single argument `onNodeDrag(node)`. | - |
 | <b>onNodeDragEnd</b>(<i>fn</i>) | Callback function for the end of node drag interactions. This function is invoked when the node is released. The node object is included as single argument `onNodeDragEnd(node)`. | - |
-| <b>onLinkClick</b>(<i>fn</i>) | Callback function for link (left-button) clicks. The link object is included as single argument `onLinkClick(link)`. | - |
+| <b>onLinkClick</b>(<i>fn</i>) | Callback function for link (left-button) clicks. The link object and the event object from the click event are included as arguments: `onLinkClick(link, event)`. | - |
 | <b>onLinkRightClick</b>(<i>fn</i>) | Callback function for link right-clicks. The link object is included as single argument `onLinkRightClick(link)`. | - |
 | <b>onLinkHover</b>(<i>fn</i>) | Callback function for link mouse over events. The link object (or `null` if there's no link under the mouse line of sight) is included as the first argument, and the previous link object (or null) as second argument: `onLinkHover(link, prevLink)`. | - |
 | <b>linkHoverPrecision</b>([<i>int</i>]) | Whether to display the link label when hovering the link closely (low value) or from far away (high value). | 4 |

--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -148,9 +148,11 @@ export default Kapsule({
     onNodeDrag: { default: () => {}, triggerUpdate: false },
     onNodeDragEnd: { default: () => {}, triggerUpdate: false },
     onNodeClick: { default: () => {}, triggerUpdate: false },
+    onNodeDoubleClick: { default: () => {}, triggerUpdate: false },
     onNodeRightClick: { triggerUpdate: false },
     onNodeHover: { default: () => {}, triggerUpdate: false },
     onLinkClick: { default: () => {}, triggerUpdate: false },
+    onLinkDoubleClick: { default: () => {}, triggerUpdate: false },
     onLinkRightClick: { triggerUpdate: false },
     onLinkHover: { default: () => {}, triggerUpdate: false },
     onBackgroundClick: { default: () => {}, triggerUpdate: false },
@@ -405,10 +407,11 @@ export default Kapsule({
       }
     }, false);
 
+
     // Handle click events on nodes/links
     container.addEventListener('click', ev => {
       if (state.hoverObj) {
-        state[`on${state.hoverObj.type}Click`](state.hoverObj.d);
+        state[`on${state.hoverObj.type}Click`](state.hoverObj.d, ev);
       } else {
         state.onBackgroundClick();
       }
@@ -421,7 +424,7 @@ export default Kapsule({
       ev.preventDefault();
       if (state.hoverObj) {
         const fn = state[`on${state.hoverObj.type}RightClick`];
-        fn && fn(state.hoverObj.d);
+        fn && fn(state.hoverObj.d, ev);
       } else {
         state.onBackgroundRightClick && state.onBackgroundRightClick();
       }


### PR DESCRIPTION
Pass the event object to the click event callbacks to allow for things like:
- More complex tooltip/info box placement
- Exposure of `shiftKey` and `ctrlKey` flags 
- Other cool things I haven't thought of yet