### PR TITLE
Expose definitions in `index.d.ts`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,9 @@
-interface GraphData {
+export interface GraphData {
   nodes: NodeObject[];
   links: LinkObject[];
 }
 
-type NodeObject = object & {
+export type NodeObject = object & {
   id?: string | number;
   x?: number;
   y?: number;
@@ -13,7 +13,7 @@ type NodeObject = object & {
   fy?: number;
 };
 
-type LinkObject = object & {
+export type LinkObject = object & {
   source?: string | number | NodeObject;
   target?: string | number | NodeObject;
 };


### PR DESCRIPTION
Exporting certain definitions like the `GraphData` interface and `NodeObject` in the typings file `index.d.ts` enables them to be utilised in the consuming app.

An example use case is where a reference is maintained to each `NodeObject` instance say, in a `Map`, to enable efficient lookup by a node ID. Exporting such types allows and encourages their re-use.