### PR TITLE
New examples for: Automatic curvature for overlapping links / Usage as UI to construct graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Check out the examples:
 * [Directional links (using arrows)](https://vasturiano.github.io/force-graph/example/directional-links-arrows/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/directional-links-arrows/index.html))
 * [Directional links (using moving particles)](https://vasturiano.github.io/force-graph/example/directional-links-particles/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/directional-links-particles/index.html))
 * [Curved lines and self links](https://vasturiano.github.io/force-graph/example/curved-links/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/curved-links/index.html))
+* [Automatic curvature for overlapping links](https://vasturiano.github.io/force-graph/example/curved-links-computed-curvature/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/curved-links-computed-curvature/index.html))
 * [Text in links](https://vasturiano.github.io/force-graph/example/text-links/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/text-links/index.html))
 * [Dash odd links](https://vasturiano.github.io/force-graph/example/dash-odd-links/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/dash-odd-links/index.html))
 * [Highlight nodes/links](https://vasturiano.github.io/force-graph/example/highlight/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/highlight/index.html))

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Check out the examples:
 * [Force-directed tree (DAG mode)](https://vasturiano.github.io/force-graph/example/tree/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/tree/index.html))
 * [Expandable Tree](https://vasturiano.github.io/force-graph/example/expandable-tree/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/expandable-tree/index.html))
 * [yarn.lock dependency graph (DAG mode)](https://vasturiano.github.io/force-graph/example/dag-yarn/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/dag-yarn/index.html))
+* [Usage as UI to construct graphs](https://vasturiano.github.io/force-graph/example/build-a-graph/) ([source](https://github.com/vasturiano/force-graph/blob/master/example/build-a-graph/index.html))
 
 See also the [3D version](https://github.com/vasturiano/3d-force-graph).
 

--- a/example/build-a-graph/index.html
+++ b/example/build-a-graph/index.html
@@ -1,0 +1,108 @@
+<head>
+  <style> body { margin: 0; } </style>
+
+  <script src="//unpkg.com/force-graph"></script>
+  <!--<script src="../../dist/force-graph.js"></script>-->
+</head>
+
+<body>
+<br/>
+<div style="text-align: center; color: silver">
+  <b>New node:</b> click on the canvas, <b>New link:</b> drag one node close enough to another one,
+  <b>Rename</b> node or link by clicking on it, <b>Remove</b> node or link by right-clicking on it
+</div>
+  <div id="graph"></div>
+
+  <script>
+    let nodeIdCounter = 0, linkIdCounter = 0;
+    let nodes = [], links = [];
+    let dragSourceNode = null, interimLink = null;
+    const snapInDistance = 15;
+    const snapOutDistance = 40;
+
+    const updateGraphData = () => {
+      Graph.graphData({ nodes: nodes, links: links });
+    };
+
+    const distance = (node1, node2) => {
+      return Math.sqrt(Math.pow(node1.x - node2.x, 2) + Math.pow(node1.y - node2.y, 2));
+    };
+
+    const rename = (nodeOrLink, type) => {
+      let value = prompt('Name this ' + type + ':', nodeOrLink.name);
+      if (!value) {
+        return;
+      }
+      nodeOrLink.name = value;
+      updateGraphData();
+    };
+
+    const setInterimLink = (source, target) => {
+      let linkId = linkIdCounter ++;
+      interimLink = { id: linkId, source: source, target: target, name: 'link_' + linkId };
+      links.push(interimLink);
+      updateGraphData();
+    };
+
+    const removeLink = link => {
+      links.splice(links.indexOf(link), 1);
+    };
+
+    const removeInterimLinkWithoutAddingIt = () => {
+      removeLink(interimLink);
+      interimLink = null;
+      updateGraphData();
+    };
+
+    const removeNode = node => {
+      links.filter(link => link.source === node || link.target === node).forEach(link => removeLink(link));
+      nodes.splice(nodes.indexOf(node), 1);
+    };
+
+    const Graph = ForceGraph()
+      (document.getElementById('graph'))
+        .linkDirectionalArrowLength(6)
+        .linkDirectionalArrowRelPos(1)
+        .onNodeDrag(dragNode => {
+          dragSourceNode = dragNode;
+          for (let node of nodes) {
+            if (dragNode === node) {
+              continue;
+            }
+            // close enough: snap onto node as target for suggested link
+            if (!interimLink && distance(dragNode, node) < snapInDistance) {
+              setInterimLink(dragSourceNode, node);
+            }
+            // close enough to other node: snap over to other node as target for suggested link
+            if (interimLink && node !== interimLink.target && distance(dragNode, node) < snapInDistance) {
+              removeLink(interimLink);
+              setInterimLink(dragSourceNode, node);
+            }
+          }
+          // far away enough: snap out of the current target node
+          if (interimLink && distance(dragNode, interimLink.target) > snapOutDistance) {
+            removeInterimLinkWithoutAddingIt();
+          }
+        })
+        .onNodeDragEnd(() => {
+          dragSourceNode = null;
+          interimLink = null;
+          updateGraphData();
+        })
+        .nodeColor(node => node === dragSourceNode || (interimLink &&
+                (node === interimLink.source || node === interimLink.target)) ? 'orange' : null)
+        .linkColor(link => link === interimLink ? 'orange' : '#bbbbbb')
+        .linkLineDash(link => link === interimLink ? [2, 2] : [])
+        .onNodeClick((node, event) => rename(node, 'node'))
+        .onNodeRightClick((node, event) => removeNode(node))
+        .onLinkClick((link, event) => rename(link, 'link'))
+        .onLinkRightClick((link, event) => removeLink(link))
+        .onBackgroundClick(event => {
+          let coords = Graph.screen2GraphCoords(event.layerX, event.layerY);
+          let nodeId = nodeIdCounter ++;
+          nodes.push({ id: nodeId, x: coords.x, y: coords.y, name: 'node_' + nodeId });
+          updateGraphData();
+        });
+    updateGraphData();
+  </script>
+</body>

--- a/example/curved-links-computed-curvature/index.html
+++ b/example/curved-links-computed-curvature/index.html
@@ -1,0 +1,76 @@
+<head>
+  <style> body { margin: 0; } </style>
+
+  <script src="//unpkg.com/force-graph"></script>
+  <!--<script src="../../dist/force-graph.js"></script>-->
+</head>
+
+<body>
+  <div id="graph"></div>
+
+  <script>
+    const gData = {
+      nodes: [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+      links: [
+        { source: 0, target: 1 },
+        { source: 0, target: 1 },
+        { source: 1, target: 0 },
+        { source: 1, target: 2 },
+        { source: 2, target: 2 },
+        { source: 2, target: 2 },
+        { source: 2, target: 2 },
+        { source: 2, target: 3 },
+        { source: 3, target: 4 },
+        { source: 4, target: 3 }
+      ]
+    };
+
+    let selfLoopLinks = {};
+    let sameNodesLinks = {};
+    const curvatureMinMax = 0.5;
+
+    // 1. assign each link a nodePairId that combines their source and target independent of the links direction
+    // 2. group links together that share the same two nodes or are self-loops
+    gData.links.forEach(link => {
+      link.nodePairId = link.source <= link.target ? (link.source + "_" + link.target) : (link.target + "_" + link.source);
+      let map = link.source === link.target ? selfLoopLinks : sameNodesLinks;
+      if (!map[link.nodePairId]) {
+        map[link.nodePairId] = [];
+      }
+      map[link.nodePairId].push(link);
+    });
+
+    // Compute the curvature for self-loop links to avoid overlaps
+    Object.keys(selfLoopLinks).forEach(id => {
+      let links = selfLoopLinks[id];
+      let lastIndex = links.length - 1;
+      links[lastIndex].curvature = 1;
+      let delta = (1 - curvatureMinMax) / lastIndex;
+      for (let i = 0; i < lastIndex; i++) {
+        links[i].curvature = curvatureMinMax + i * delta;
+      }
+    });
+
+    // Compute the curvature for links sharing the same two nodes to avoid overlaps
+    Object.keys(sameNodesLinks).filter(nodePairId => sameNodesLinks[nodePairId].length > 1).forEach(nodePairId => {
+      let links = sameNodesLinks[nodePairId];
+      let lastIndex = links.length - 1;
+      let lastLink = links[lastIndex];
+      lastLink.curvature = curvatureMinMax;
+      let delta = 2 * curvatureMinMax / lastIndex;
+      for (let i = 0; i < lastIndex; i++) {
+        links[i].curvature = - curvatureMinMax + i * delta;
+        if (lastLink.source !== links[i].source) {
+          links[i].curvature *= -1; // flip it around, otherwise they overlap
+        }
+      }
+    });
+
+    const Graph = ForceGraph()
+      (document.getElementById('graph'))
+        .linkCurvature('curvature')
+        .linkDirectionalArrowLength(6)
+        .linkDirectionalArrowRelPos(1)
+        .graphData(gData);
+  </script>
+</body>


### PR DESCRIPTION
Hi @vasturiano, thanks for providing and maintaining this library, super useful!

I am using it for a tinker-project of mine where my graph can contain multiple links between the same nodes and multiple self-links. To not have to set the curvature values manually in order to avoid overlap of links, I created a bit of code that computes the curvature for those cases.
Furthermore I needed functionality to construct new graphs in a simple and intuitive way and achieved it by utilising the drag and click handlers you provide.

I created examples for both of these cases, hoping that you might find them cool and thinking that others might benefit from them. Happy to make adjustments or split it into two PRs if you want.

**curved-links-computed-curvature**:
![Screenshot 2021-07-16 at 18 00 09](https://user-images.githubusercontent.com/5141792/125980046-8eeb87e7-de1a-435c-90ee-5a96fe78ecb3.png)

**build-a-graph**:

https://user-images.githubusercontent.com/5141792/125980259-c6a26733-c340-4699-9d3e-a7cd0765b576.mov
