### PR TITLE
Updated type signature of nodeCanvasObjectMode

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -72,8 +72,8 @@ export interface ForceGraphGenericInstance<ChainableInstance> {
   nodeAutoColorBy(colorByAccessor: NodeAccessor<string | null>): ChainableInstance;
   nodeCanvasObject(): CanvasCustomRenderFn<NodeObject>;
   nodeCanvasObject(renderFn: CanvasCustomRenderFn<NodeObject>): ChainableInstance;
-  nodeCanvasObjectMode(): string | ((obj: NodeObject) => CanvasCustomRenderMode);
-  nodeCanvasObjectMode(modeAccessor: string | ((obj: NodeObject) => CanvasCustomRenderMode)): ChainableInstance;
+  nodeCanvasObjectMode(): string | ((obj: NodeObject) => CanvasCustomRenderMode | undefined);
+  nodeCanvasObjectMode(modeAccessor: string | ((obj: NodeObject) => CanvasCustomRenderMode | undefined)): ChainableInstance;
   nodePointerAreaPaint(): CanvasPointerAreaPaintFn<NodeObject>;
   nodePointerAreaPaint(renderFn: CanvasPointerAreaPaintFn<NodeObject>): ChainableInstance;
 


### PR DESCRIPTION
This allows undefined in nodeCanvasObjectMode, which is in line with the examples provided

closes #254 