### PR TITLE
Prevent initial graph-tooltip overflow

### DIFF
--- a/src/force-graph.css
+++ b/src/force-graph.css
@@ -7,6 +7,8 @@
 
 .force-graph-container .graph-tooltip {
   position: absolute;
+  left: 0; /* initial position to prevent overflow */
+  top: 0; /* initial position to prevent overflow */
   transform: translate(-50%, 25px);
   font-family: sans-serif;
   font-size: 16px;


### PR DESCRIPTION
## Problem

When the graph first loads, the graph-tooltip causes the container to overflow because of its position (below the canvas). This problem is fixed once the cursor is moved, but it causes the browser to display a scrollbar upon page load.

## Solution

Set a default position at the top-left corner of the screen to prevent x- or y-axis overflows.