### PR TITLE
Allow module augmentation for NodeObject and LinkObject types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ export interface GraphData {
   links: LinkObject[];
 }
 
-export type NodeObject = object & {
+export interface NodeObject {
   id?: string | number;
   x?: number;
   y?: number;
@@ -11,12 +11,12 @@ export type NodeObject = object & {
   vy?: number;
   fx?: number;
   fy?: number;
-};
+}
 
-export type LinkObject = object & {
+export interface LinkObject {
   source?: string | number | NodeObject;
   target?: string | number | NodeObject;
-};
+}
 
 type Accessor<In, Out> = Out | string | ((obj: In) => Out);
 type NodeAccessor<T> = Accessor<NodeObject, T>;


### PR DESCRIPTION
this changes the `NodeObject` and `LinkObject` types to interfaces, to enable [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).

this would enable users to specify node/edge properties like this:

```ts
declare module 'force-graph' {
  interface NodeObject {
    key: string
    label: string
  }

  interface LinkObject {
    key: string
    label: string
  }
}
```