### PR TITLE
Export some more types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,8 +23,9 @@ type NodeAccessor<T> = Accessor<NodeObject, T>;
 type LinkAccessor<T> = Accessor<LinkObject, T>;
 
 type CanvasCustomRenderMode = 'replace' | 'before' | 'after';
-type CanvasCustomRenderFn<T> = (obj: T, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
-type CanvasPointerAreaPaintFn<T> = (obj: T, paintColor: string, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
+export type CanvasCustomRenderModeFn<T> = (obj: T) => CanvasCustomRenderMode;
+export type CanvasCustomRenderFn<T> = (obj: T, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
+export type CanvasPointerAreaPaintFn<T> = (obj: T, paintColor: string, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
 
 type DagMode = 'td' | 'bu' | 'lr' | 'rl' | 'radialout' | 'radialin';
 
@@ -72,8 +73,8 @@ export interface ForceGraphGenericInstance<ChainableInstance> {
   nodeAutoColorBy(colorByAccessor: NodeAccessor<string | null>): ChainableInstance;
   nodeCanvasObject(): CanvasCustomRenderFn<NodeObject>;
   nodeCanvasObject(renderFn: CanvasCustomRenderFn<NodeObject>): ChainableInstance;
-  nodeCanvasObjectMode(): string | ((obj: NodeObject) => CanvasCustomRenderMode | any);
-  nodeCanvasObjectMode(modeAccessor: string | ((obj: NodeObject) => CanvasCustomRenderMode | any)): ChainableInstance;
+  nodeCanvasObjectMode(): string | CanvasCustomRenderModeFn<NodeObject>;
+  nodeCanvasObjectMode(modeAccessor: string | CanvasCustomRenderModeFn<NodeObject>): ChainableInstance;
   nodePointerAreaPaint(): CanvasPointerAreaPaintFn<NodeObject>;
   nodePointerAreaPaint(renderFn: CanvasPointerAreaPaintFn<NodeObject>): ChainableInstance;
 
@@ -94,8 +95,8 @@ export interface ForceGraphGenericInstance<ChainableInstance> {
   linkCurvature(curvatureAccessor: LinkAccessor<number>): ChainableInstance;
   linkCanvasObject(): CanvasCustomRenderFn<LinkObject>;
   linkCanvasObject(renderFn: CanvasCustomRenderFn<LinkObject>): ChainableInstance;
-  linkCanvasObjectMode(): string | ((obj: LinkObject) => CanvasCustomRenderMode);
-  linkCanvasObjectMode(modeAccessor: string | ((obj: LinkObject) => CanvasCustomRenderMode)): ChainableInstance;
+  linkCanvasObjectMode(): string | CanvasCustomRenderModeFn<LinkObject>;
+  linkCanvasObjectMode(modeAccessor: string | CanvasCustomRenderModeFn<LinkObject>): ChainableInstance;
   linkDirectionalArrowLength(): LinkAccessor<number>;
   linkDirectionalArrowLength(lengthAccessor: LinkAccessor<number>): ChainableInstance;
   linkDirectionalArrowColor(): LinkAccessor<string>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ type NodeAccessor<T> = Accessor<NodeObject, T>;
 type LinkAccessor<T> = Accessor<LinkObject, T>;
 
 type CanvasCustomRenderMode = 'replace' | 'before' | 'after';
-export type CanvasCustomRenderModeFn<T> = (obj: T) => CanvasCustomRenderMode;
+export type CanvasCustomRenderModeFn<T> = (obj: T) => CanvasCustomRenderMode | any;
 export type CanvasCustomRenderFn<T> = (obj: T, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
 export type CanvasPointerAreaPaintFn<T> = (obj: T, paintColor: string, canvasContext: CanvasRenderingContext2D, globalScale: number) => void;
 


### PR DESCRIPTION
follow-up to https://github.com/vasturiano/force-graph/pull/271#issuecomment-1179009285

main usecase is to allow defining functions passed to `nodeCanvasObjectMode`, `nodeCanvasObject` and `nodeCanvasPaintArea` separately instead of inline:

before:
```ts
fg.nodeCanvasObjectMode((node) => {
  return 'before'
})
fg.nodeCanvasObject((node, ctx, globalScale) => {
  /** ... */
})
fg.nodePointerAreaPaint((node, color, ctx, globalScale) => {
  /** ... */
})
```

after:
```ts
import type { CanvasCustomRenderModeFn, CanvasCustomRenderFn, CanvasPointerAreaPaintFn, NodeObject } from 'force-graph'

const nodeCanvasObjectMode: CanvasCustomRenderModeFn<NodeObject> = (node) => {
  /** ... */
  return 'before'
}
const nodeCanvasObject: CanvasCustomRenderFn<NodeObject> = (node, ctx, globalScale) => {
  /** ... */
}
const nodePointerAreaPaint: CanvasPointerAreaPaintFn<NodeObject> = (node, color, ctx, globalScale) => {
  /** ... */
}

fg.nodeCanvasObjectMode(nodeCanvasObjectMode)
fg.nodeCanvasObject(nodeCanvasObject)
fg.nodePointerAreaPaint(nodePointerAreaPaint)
```