### PR TITLE
fix canvas resize bug

### DIFF
--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -366,7 +366,8 @@ export default Kapsule({
 
     const ctx = state.canvas.getContext('2d');
     const shadowCtx = state.shadowCanvas.getContext('2d');
-
+    window.addEventListener('resize', () => adjustCanvasSize(state))
+    
     const pointerPos = { x: -1e12, y: -1e12 };
     const getObjUnderPointer = () => {
       let obj = null;


### PR DESCRIPTION
This PR fixes the bug described on #279. The problem was that the canvas was not resizing when zooming with the browser. Zooming with the browser changes the devicePixelRatio, so it is needed to update this on the canvas size. Adding this listener triggers the update when resizing and zooming, though there may be a better way to do this.