### PR TITLE
types: allow disabling force by passing `null`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -148,7 +148,7 @@ export interface ForceGraphGenericInstance<ChainableInstance> {
   d3VelocityDecay(): number;
   d3VelocityDecay(velocityDecay: number): ChainableInstance;
   d3Force(forceName: 'link' | 'charge' | 'center' | string): ForceFn | undefined;
-  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn): ChainableInstance;
+  d3Force(forceName: 'link' | 'charge' | 'center' | string, forceFn: ForceFn | null): ChainableInstance;
   d3ReheatSimulation(): ChainableInstance;
   warmupTicks(): number;
   warmupTicks(ticks: number): ChainableInstance;


### PR DESCRIPTION
afaiu it is possible to disable a force by passing `null` - this pr adjusts the types to account for that