### PR TITLE
types: support disabling dag mode

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -134,7 +134,7 @@ export interface ForceGraphGenericInstance<ChainableInstance> {
 
   // Force engine (d3-force) configuration
   dagMode(): DagMode;
-  dagMode(mode: DagMode): ChainableInstance;
+  dagMode(mode: DagMode | false): ChainableInstance;
   dagLevelDistance(): number | null;
   dagLevelDistance(distance: number): ChainableInstance;
   dagNodeFilter(): (node: NodeObject) => boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -133,8 +133,8 @@ export interface ForceGraphGenericInstance<ChainableInstance> {
   onRenderFramePost(callback: (canvasContext: CanvasRenderingContext2D, globalScale: number) => void): ChainableInstance;
 
   // Force engine (d3-force) configuration
-  dagMode(): DagMode;
-  dagMode(mode: DagMode | false): ChainableInstance;
+  dagMode(): DagMode | null;
+  dagMode(mode: DagMode | null): ChainableInstance;
   dagLevelDistance(): number | null;
   dagLevelDistance(distance: number): ChainableInstance;
   dagNodeFilter(): (node: NodeObject) => boolean;


### PR DESCRIPTION
Hi, I noticed disabling dag mode has been supported in JS and it did work through my experiment.

https://github.com/vasturiano/force-graph/blob/382872a1829a693b16eb62891a086347f0060409/src/canvas-force-graph.js#L37-L39

This PR allows disabling dag mode when writing in TS, e.g. `graph.dagMode(false)`
