### PR TITLE
fix: add types to exports map in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "module": "dist/force-graph.mjs",
   "types": "src/index.d.ts",
   "exports": {
+		"types": "./src/index.d.ts",
     "umd": "./dist/force-graph.min.js",
     "default": "./dist/force-graph.mjs"
   },


### PR DESCRIPTION
this adds `types` to the package.json `exports` map - otherwise i am getting the following error with ts:

```
Could not find a declaration file for module 'force-graph'.
  There are types at '/XXX/node_modules/force-graph/src/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'force-graph' library may need to update its package.json or typings.
```