### PR TITLE
Fix: Require pointerdown on canvas to trigger pointerup

### DIFF
--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -547,6 +547,10 @@ export default Kapsule({
 
     // Handle click/touch events on nodes/links
     container.addEventListener('pointerup', ev => {
+      if (!state.isPointerPressed) {
+        return; // don't trigger click events if pointer is not pressed on the canvas
+      }
+
       state.isPointerPressed = false;
       if (state.isPointerDragging) {
         state.isPointerDragging = false;


### PR DESCRIPTION
This updates the `pointerup` event, to require the user to have triggered `pointerdown` on the canvas object.

# Reason
Presently, if a user triggers `pointerdown` anywhere else (such as using radix/shadcn dialogs, sidebars, etc. or even outside of the browser) and then drags their mouse into the canvas and releases their mouse button, the `pointerup` event triggers. This can cause confusion as developers add interactions such as `onNodeClick` or `onBackgroundClick`, as these are triggering without the user realizing they interacted with the graph.