### PR TITLE
Fix Microsoft Teams screensharing click vs drag issue on Windows and Chrome

### DIFF
--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -283,7 +283,7 @@ export default Kapsule({
     },
     zoomToFit: function(state, transitionDuration = 0, padding = 10, ...bboxArgs) {
       const bbox = this.getGraphBbox(...bboxArgs);
-      
+
       if (bbox) {
         const center = {
           x: (bbox.x[0] + bbox.x[1]) / 2,
@@ -432,8 +432,10 @@ export default Kapsule({
           ['x', 'y'].forEach(c => obj[`f${c}`] = obj[c] = initPos[c] + (dragPos[c] - initPos[c]) / k);
 
           // Only engage full drag if distance reaches above threshold
-          if (!obj.__dragged && (DRAG_CLICK_TOLERANCE_PX >= Math.sqrt(d3Sum(['x', 'y'].map(k => (ev[k] - initPos[k])**2)))))
+          if (!obj.__dragged && (DRAG_CLICK_TOLERANCE_PX >= Math.sqrt(d3Sum(['x', 'y'].map(k => (ev[k] - initPos[k])**2))))) {
+            state.isPointerDragging = false;
             return;
+          }
 
           state.forceGraph
             .d3AlphaTarget(0.3) // keep engine running at low intensity throughout drag


### PR DESCRIPTION
# Description

Thanks for the great repo! The performance is great and easy to use.

This PR fixes a minor issue when screen-sharing through Teams on Windows and Chrome.

I noticed every time screen-share mode is on there is always an extra `pointermove`
event. This put the `isPointerDragging` state **always** into `true`. This ensures
when the movement is below our tolerance we reset the dragging state off
allowing us to catch `onNodeClick` event.

Context: This [tolerance commit](https://github.com/vasturiano/force-graph/commit/3445cf9ccd521684fb74f6d4c59837fdf3926133#diff-61f60028ded259b203d4401e655a67b405b14931e47f309a4221a8c98788fc7aR433)

Fixes https://github.com/vasturiano/react-force-graph/issues/383 and https://github.com/vasturiano/react-force-graph/issues/425

# Reproduce

Launch Microsoft Teams and start screen-sharing and target the chrome window
with the graph. In your `handleClick` and `handleDrag` try to log the events
that happens. You will see that it always output "drag" even after the tolerance fix.

You can see pointer events using this in Chrome console `monitorEvents(document.querySelector('canvas'), 'pointer')`
