### PR TITLE
onNodeClick missed due to no-op pointermove event (Chrome on Windows)

### DIFF
--- a/src/force-graph.js
+++ b/src/force-graph.js
@@ -529,6 +529,7 @@ export default Kapsule({
         !state.isPointerDragging && ev.type === 'pointermove'
         && (state.onBackgroundClick) // only bother detecting drags this way if background clicks are enabled (so they don't trigger accidentally on canvas panning)
         && (ev.pressure > 0 || state.isPointerPressed) // ev.pressure always 0 on Safari, so we use the isPointerPressed tracker
+        && (ev.pointerType !== 'mouse' || ev.movementX !== 0 || ev.movementY !== 0) // ignore mouse events with no movement (see: https://issues.chromium.org/issues/325530041); movementX/Y can still be undefined in some browsers, don't ignore such events
         && (ev.pointerType === 'mouse' || ev.movementX === undefined || [ev.movementX, ev.movementY].some(m => Math.abs(m) > 1)) // relax drag trigger sensitivity on non-mouse (touch/pen) events
         && (state.isPointerDragging = true);
 


### PR DESCRIPTION
Fixes force-graph to properly handle node click events when there is a spurious `pointermove` event without movement between the `pointerdown` and `pointerup` events. In some cases, when pressing the mouse click, the browser triggers a `pointermove` event (without movement!) immediately after the `pointerdown` event. The spurious event can be unambiguously identified when `movementX === movementY === 0`.

**Normal sequence of events when a user clicks and releases the mouse button:**

1. `pointerdown` event
2. `pointerup` event --> force-graph triggers `onNodeClick` as expected because `state.isPointerDragging` will be false. See: https://github.com/vasturiano/force-graph/blob/df18bc04ab497f268d2b38e100762a6a745e16ee/src/force-graph.js#L552-L561


**Problematic sequence of events**

_(repro's on Windows / Edge, but only when sharing the browser window with programs such as Teams (!!); online reports indicate there are other weird conditions that also trigger this (see: https://issues.chromium.org/issues/325530041, https://issues.chromium.org/issues/41435421))_

1. `pointerdown` event
2. `pointermove` event with `movementX === movementY === 0` --> this causes `state.isPointerDragging` to be updated to `true` (!)
3. `pointerup` event --> force-graph does NOT trigger `onNodeClick` because `state.isPointerDragging === true`, which was not intended

This change is the least intrusive way to handle this. While in an ideal world this would not be necessary and the issue seems to be a bug in Chrome, this change seems plausible and harmless. NOTE: This change was cautious to avoid breaking compatibility with browsers that may not support `movementX` and `movementY` in the PointerEvents; in those cases, as long as those browsers aren't always setting these properties to zero, this will work. This is also the recommended workaround here: https://forum.babylonjs.com/t/google-chrome-started-firing-pointermove-events-for-pointerdown/3202/7

