### PR TITLE
Fix negative particle speed causing particles to escape link

### DIFF
--- a/src/canvas-force-graph.js
+++ b/src/canvas-force-graph.js
@@ -409,7 +409,6 @@ export default Kapsule({
             !singleHop && cyclePhotonIdx++; // increase regular photon index
 
             photon.__progressRatio += particleSpeed;
-            
             if (photon.__progressRatio >= 1) {
               if (!singleHop) {
                 photon.__progressRatio = photon.__progressRatio % 1;

--- a/src/canvas-force-graph.js
+++ b/src/canvas-force-graph.js
@@ -409,10 +409,17 @@ export default Kapsule({
             !singleHop && cyclePhotonIdx++; // increase regular photon index
 
             photon.__progressRatio += particleSpeed;
-
-            if (photon.__progressRatio >=1) {
+            
+            if (photon.__progressRatio >= 1) {
               if (!singleHop) {
                 photon.__progressRatio = photon.__progressRatio % 1;
+              } else {
+                needsCleanup = true;
+                return;
+              }
+            } else if (photon.__progressRatio < 0) {
+              if (!singleHop) {
+                photon.__progressRatio = 1 + (photon.__progressRatio % 1);
               } else {
                 needsCleanup = true;
                 return;


### PR DESCRIPTION
Thanks for the great library, I use it for https://github.com/foambubble/foam and love it.
I noticed a bug when I put a negative value in the particle speed of a link, the particles will travel along an extrapolated line past the source node indefinitely, instead of wrapping backwards.

I implemented a fix and tested it locally (but please do triple check).